### PR TITLE
group,off_by,off_mode,off_timeの実装

### DIFF
--- a/SFZ_MIDI_Player/include/SFZLoader.hpp
+++ b/SFZ_MIDI_Player/include/SFZLoader.hpp
@@ -8,7 +8,7 @@ enum class Trigger : uint8
 
 enum class OffMode : uint8
 {
-	Fast, Normal
+	Fast, Normal, Time
 };
 
 // https://musf.ifdef.jp/sfz/sfz_File_Format.html
@@ -27,6 +27,7 @@ struct RegionSetting
 	uint32 group = 0;
 	uint32 off_by = 0;
 	OffMode off_mode = OffMode::Fast;
+	float off_time = 0.006f;
 
 	// Sample Player
 	uint32 offset = 0;

--- a/SFZ_MIDI_Player/include/SFZLoader.hpp
+++ b/SFZ_MIDI_Player/include/SFZLoader.hpp
@@ -6,6 +6,11 @@ enum class Trigger : uint8
 	Attack, Release, First, Legato
 };
 
+enum class OffMode : uint8
+{
+	Fast, Normal
+};
+
 // https://musf.ifdef.jp/sfz/sfz_File_Format.html
 struct RegionSetting
 {
@@ -17,6 +22,11 @@ struct RegionSetting
 	uint8 lokey = 0;
 	uint8 hikey = 127;
 	Trigger trigger = Trigger::Attack;
+
+	// group番号は1以上（0はグループに所属しない）
+	uint32 group = 0;
+	uint32 off_by = 0;
+	OffMode off_mode = OffMode::Fast;
 
 	// Sample Player
 	uint32 offset = 0;

--- a/SFZ_MIDI_Player/include/SampleSource.hpp
+++ b/SFZ_MIDI_Player/include/SampleSource.hpp
@@ -1,15 +1,18 @@
 ﻿#pragma once
 #include <Siv3D.hpp>
+#include "SFZLoader.hpp"
 
 struct KeyDownEvent
 {
 	int8 key;
 	int64 pressTimePos;
+	uint8 velocity;
 
 	KeyDownEvent() = delete;
-	KeyDownEvent(int8 key, int64 pressTimePos) :
+	KeyDownEvent(int8 key, int64 pressTimePos, uint8 velocity) :
 		key(key),
-		pressTimePos(pressTimePos)
+		pressTimePos(pressTimePos),
+		velocity(velocity)
 	{}
 };
 
@@ -20,6 +23,8 @@ struct NoteEvent
 	int64 pressTimePos;
 	int64 releaseTimePos;
 	uint8 velocity;
+
+	Optional<int64> disableTimePos;
 
 	NoteEvent() = delete;
 	NoteEvent(int64 attackIndex, int64 releaseIndex, int64 pressTimePos, int64 releaseTimePos, uint8 velocity) :
@@ -109,6 +114,13 @@ public:
 		m_swDefault = swDefault;
 	}
 
+	void setGroup(uint32 group, uint32 offBy, float disableFadeSeconds)
+	{
+		m_group = group;
+		m_offBy = offBy;
+		m_disableFadeSeconds = disableFadeSeconds;
+	}
+
 	bool isValidVelocity(uint8 velocity) const
 	{
 		return m_lovel <= velocity && velocity <= m_hivel;
@@ -132,6 +144,10 @@ public:
 
 	bool isOscillator() const { return m_oscillatorType.has_value(); }
 
+	uint32 group() const { return m_group; }
+	uint32 offBy() const { return m_offBy; }
+	float disableFadeSeconds() const { return m_disableFadeSeconds; }
+
 private:
 
 	Optional<OscillatorType> m_oscillatorType;
@@ -154,6 +170,10 @@ private:
 	int8 m_swHikey = 0;
 	int8 m_swLast = 0;
 	int8 m_swDefault = 0;
+
+	uint32 m_group = 0;
+	uint32 m_offBy = 0;
+	float m_disableFadeSeconds = 0;
 };
 
 // 1つのキーから鳴らされるAudioSourceをまとめたもの
@@ -175,6 +195,8 @@ public:
 
 	int64 getAttackIndex(uint8 velocity, int64 pressTimePos, const Array<KeyDownEvent>& history) const;
 
+	const AudioSource& getAttackKey(int64 attackIndex) const;
+
 	int64 getReleaseIndex(uint8 velocity) const;
 
 	void debugPrint() const;
@@ -184,6 +206,8 @@ public:
 	void deleteDuplicate();
 
 	void getSamples(float* left, float* right, int64 startPos, int64 sampleCount);
+
+	Array<NoteEvent>& noteEvents() { return m_noteEvents; }
 
 private:
 

--- a/SFZ_MIDI_Player/source/SFZLoader.cpp
+++ b/SFZ_MIDI_Player/source/SFZLoader.cpp
@@ -54,6 +54,10 @@ namespace
 		{
 			return OffMode::Normal;
 		}
+		else if (trigger == U"time")
+		{
+			return OffMode::Time;
+		}
 
 		assert(false);
 		return OffMode::Fast;
@@ -276,6 +280,7 @@ SfzData LoadSfz(FilePathView sfzPath)
 	const String keyGroup = U"group=";
 	const String keyOffBy = U"off_by=";
 	const String keyOffMode = U"off_mode=";
+	const String keyOffTime = U"off_time=";
 
 	const auto parentDirectory = FileSystem::ParentPath(sfzPath);
 	String defaultPath = parentDirectory;
@@ -350,6 +355,10 @@ SfzData LoadSfz(FilePathView sfzPath)
 		else if (token.starts_with(keyOffMode))
 		{
 			(region ? region.value() : group).off_mode = ParseOffMode(token.substr(keyOffMode.length()));
+		}
+		else if (token.starts_with(keyOffTime))
+		{
+			(region ? region.value() : group).off_time = ParseFloat<float>(token.substr(keyOffTime.length()));
 		}
 		else if (token.starts_with(keySwLoKey))
 		{

--- a/SFZ_MIDI_Player/source/SFZLoader.cpp
+++ b/SFZ_MIDI_Player/source/SFZLoader.cpp
@@ -44,6 +44,21 @@ namespace
 		}
 	}
 
+	OffMode ParseOffMode(StringView trigger)
+	{
+		if (trigger == U"fast")
+		{
+			return OffMode::Fast;
+		}
+		else if (trigger == U"normal")
+		{
+			return OffMode::Normal;
+		}
+
+		assert(false);
+		return OffMode::Fast;
+	}
+
 	Optional<uint8> ParseMidiKey(StringView str)
 	{
 		std::map<String, uint8> keys;
@@ -235,7 +250,7 @@ SfzData LoadSfz(FilePathView sfzPath)
 
 	TextReader sfzReader(sfzPath);
 
-	const String keyGroup = U"<group>";
+	const String keyGroupHeader = U"<group>";
 	const String keyRegion = U"<region>";
 	const String keySample = U"sample=";
 	const String keyLovel = U"lovel=";
@@ -258,6 +273,9 @@ SfzData LoadSfz(FilePathView sfzPath)
 	const String keySwHiKey = U"sw_hikey=";
 	const String keySwDefault = U"sw_default=";
 	const String keySwLast = U"sw_last=";
+	const String keyGroup = U"group=";
+	const String keyOffBy = U"off_by=";
+	const String keyOffMode = U"off_mode=";
 
 	const auto parentDirectory = FileSystem::ParentPath(sfzPath);
 	String defaultPath = parentDirectory;
@@ -320,6 +338,18 @@ SfzData LoadSfz(FilePathView sfzPath)
 					region = none;
 				}
 			}
+		}
+		else if (token.starts_with(keyGroup))
+		{
+			(region ? region.value() : group).group = ParseInt<uint32>(token.substr(keyGroup.length()));
+		}
+		else if (token.starts_with(keyOffBy))
+		{
+			(region ? region.value() : group).off_by = ParseInt<uint32>(token.substr(keyOffBy.length()));
+		}
+		else if (token.starts_with(keyOffMode))
+		{
+			(region ? region.value() : group).off_mode = ParseOffMode(token.substr(keyOffMode.length()));
 		}
 		else if (token.starts_with(keySwLoKey))
 		{
@@ -433,7 +463,7 @@ SfzData LoadSfz(FilePathView sfzPath)
 		{
 			(region ? region.value() : group).rt_decay = ParseFloat<float>(token.substr(keyRtDecay.length()));
 		}
-		else if (token.starts_with(keyGroup))
+		else if (token.starts_with(keyGroupHeader))
 		{
 			nextPos = pos + keyRegion.length() - 1;
 			if (region)

--- a/SFZ_MIDI_Player/source/SamplePlayer.cpp
+++ b/SFZ_MIDI_Player/source/SamplePlayer.cpp
@@ -163,7 +163,15 @@ void SamplePlayer::loadData(const SfzData& sfzData)
 
 			source.setSwitch(data.sw_lokey, data.sw_hikey, data.sw_last, data.sw_default);
 
-			const auto offTime = data.off_mode == OffMode::Fast ? 0.006f : data.ampeg_release;
+			float offTime = 0.006f;
+			if (data.off_mode == OffMode::Time)
+			{
+				offTime = data.off_time;
+			}
+			else if (data.off_mode == OffMode::Normal)
+			{
+				offTime = data.ampeg_release;
+			}
 			source.setGroup(data.group, data.off_by, offTime);
 
 			if (data.trigger == Trigger::Attack)


### PR DESCRIPTION
off_byが1以上のノートについて、pressTime～releaseTimeまでのノートオンイベントを調べる
その中で最初の該当groupのノートオンイベントがあったら、その時刻をノートオフタイムとして、さらにOffMode==Fastだった場合は即座に終了する

オフされてからのフェードアウトのさせ方
- attack中やdecay中だと単にreleaseさせるだけでは不連続になる（通常のノートオフと同様）
- ただし通常のノートオフと同じようにリリースを遅延させてしまうと、鳴ったら困る音を消せなくなる
したがってoff_by専用のrelease時間を定義しておき、off_byによるノートオフ以降は通常のエンベロープにoff_byのフェードアウトを乗算する

#3 